### PR TITLE
Developer platform driven configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ build/
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
 Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+.ruby-version
+.ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
- - 1.9
  - 2.1
  - 2.2
  - 2.3

--- a/README.md
+++ b/README.md
@@ -67,7 +67,48 @@ gem 'maestrano'
 
 
 ### Configuration
-Once installed the first step is to create an initializer to configure the behaviour of the Maestrano gem - including setting your API key.
+Once installed the first step is to create an initializer to configure the behaviour of the Maestrano gem
+
+#### Configuration based of the Developer Platform
+Your environment configuration is retrieved from the developer platform where your different environments are registered.
+In your initializer add the following configuration:
+
+`config/initializers/maestrano.rb`
+```ruby
+Maestrano.auto_configure('config/dev_platform.yml')
+```
+
+`dev_platform.yml`
+```yml
+dev_platform:
+  host: 'https://dev-platform.maestrano.com'
+  api_path: '/api/config/v1/marketplaces'
+
+environment:
+  name: 'my-environment'
+  api_key: 'your-environment-api-key'
+  api_secret: 'your-environment-api-secret'
+```
+
+The API keys can be found under your Environment settings on the developer platform.
+
+Note that the configuration can also be set from environment variables:
+
+```bash
+export MNO_DEVPL_HOST=<developer platform host>
+export MNO_DEVPL_CONFIG_API=<developer platform path>
+export MNO_DEVPL_ENV_NAME=<your environment nid>
+export MNO_DEVPL_ENV_KEY=<your environment key>
+export MNO_DEVPL_ENV_SECRET=<your environment secret>
+```
+
+`config/initializers/maestrano.rb`
+```ruby
+Maestrano.auto_configure
+```
+
+#### Configure environments manually - Deprecated
+Environments configuration should be driven from the developer platform configuration. For backward compatibility purpose, environments can still be defined manually.
 
 You can add configuration presets by putting additional configuration blocks in your maestrano.rb initializer. These additional presets can then be specified when doing particular action, such as initializing a Connec!™ client or triggering a SSO handshake. These presets are particularly useful if you are dealing with multiple Maestrano-style marketplaces (multi-enterprise integration).
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note that the configuration can also be set from environment variables:
 
 ```bash
 export MNO_DEVPL_HOST=<developer platform host>
-export MNO_DEVPL_CONFIG_API=<developer platform path>
+export MNO_DEVPL_API_PATH=<developer platform path>
 export MNO_DEVPL_ENV_NAME=<your environment nid>
 export MNO_DEVPL_ENV_KEY=<your environment key>
 export MNO_DEVPL_ENV_SECRET=<your environment secret>

--- a/lib/maestrano.rb
+++ b/lib/maestrano.rb
@@ -60,9 +60,13 @@ require 'maestrano/account/recurring_bill'
 # Connec
 require 'maestrano/connec/client'
 
+# Dev platform
+require 'maestrano/auto_configure'
+
+
 module Maestrano
   include Preset
-  
+
   class << self
     attr_accessor :configs
   end
@@ -152,6 +156,12 @@ module Maestrano
     end
     
     return hash
+  end
+
+  def self.auto_configure(config_file_path = nil)
+    AutoConfigure.get_marketplace_configurations(config_file_path)
+  rescue => e
+    raise "Error while fetching dynamic configuration: #{e}. Backtrace: #{e.backtrace}"
   end
 
   class Configuration
@@ -269,7 +279,7 @@ module Maestrano
       end
     end
     
-    EVT_CONFIG = {
+    EVT_CONFIG ||= {
       'local' => {
         'api.host'             => 'http://application.maestrano.io',
         'api.base'             => '/api/v1/',

--- a/lib/maestrano/auto_configure.rb
+++ b/lib/maestrano/auto_configure.rb
@@ -6,21 +6,19 @@ module Maestrano
         request = RestClient::Request.new(
           method: :get,
           url: "#{devpl_config[:host]}#{devpl_config[:v1_path]}",
-          user: devpl_config[:api_key],
-          password: devpl_config[:api_secret],
-          headers: {
-            accept: :json
-          }
+          user: devpl_config[:env_api_key],
+          password: devpl_config[:env_api_secret],
+          headers: {accept: :json, content_type: :json}
         )
         response = request.execute
         hash = JSON.parse(response.to_s)
       rescue => e
         raise "No or bad response received from dev platform: #{e}"
       end
-puts "PARSING CONFIG: #{hash}"
+
       hash['marketplaces'].each do |marketplace|
         Maestrano[marketplace['marketplace']].configure do |config|
-          config.environment = marketplace['environment']
+          config.environment = marketplace['marketplace']
 
           [:app, :sso, :api, :webhook, :connec].each do |s|
             (marketplace[s.to_s] || {}).each do |k, v|

--- a/lib/maestrano/auto_configure.rb
+++ b/lib/maestrano/auto_configure.rb
@@ -38,7 +38,7 @@ module Maestrano
 
       devpl_config = {}
       devpl_config[:host] = ENV['MNO_DEVPL_HOST'] || yaml_config['dev_platform']['host']
-      devpl_config[:v1_path] = ENV['MNO_DEVPL_V1_PATH'] || yaml_config['dev_platform']['v1_path']
+      devpl_config[:api_path] = ENV['⁠⁠⁠⁠MNO_DEVPL_API_PATH'] || yaml_config['dev_platform']['api_path']
 
       devpl_config[:env_name] = ENV['MNO_DEVPL_ENV_NAME'] || yaml_config['environment']['name']
       devpl_config[:env_api_key] = ENV['MNO_DEVPL_ENV_KEY'] || yaml_config['environment']['api_key']

--- a/lib/maestrano/auto_configure.rb
+++ b/lib/maestrano/auto_configure.rb
@@ -1,0 +1,54 @@
+module Maestrano
+  module AutoConfigure
+    def self.get_marketplace_configurations(config_file_path = nil)
+      devpl_config = dev_platform_config(config_file_path)
+      begin
+        request = RestClient::Request.new(
+          method: :get,
+          url: "#{devpl_config[:host]}#{devpl_config[:v1_path]}",
+          user: devpl_config[:api_key],
+          password: devpl_config[:api_secret],
+          headers: {
+            accept: :json
+          }
+        )
+        response = request.execute
+        response = JSON.parse(response.to_s)
+      rescue => e
+        raise "No or bad response received from dev platform: #{e}"
+      end
+
+      response['marketplaces'].each do |marketplace|
+        Maestrano[marketplace['marketplace']].configure do |config|
+          config.environment = marketplace['environment']
+
+          [:app, :sso, :api, :webhook, :connec].each do |s|
+            (marketplace[s.to_s] || {}).each do |k, v|
+              config.send(s).send("#{k}=", v)
+            end
+          end
+        end
+      end
+    end
+
+    def self.dev_platform_config(config_file_path = nil)
+      begin
+        yaml_config = YAML.load_file("#{Dir.pwd}/#{config_file_path}")
+      rescue 
+        yaml_config = {'dev_platform' => {}, 'environment' => {}}
+      end
+
+      devpl_config = {}
+      devpl_config[:host] = ENV['MNO_DEVPL_HOST'] || yaml_config['dev_platform']['host']
+      devpl_config[:v1_path] = ENV['MNO_DEVPL_V1_PATH'] || yaml_config['dev_platform']['v1_path']
+
+      devpl_config[:env_name] = ENV['MNO_DEVPL_ENV_NAME'] || yaml_config['environment']['name']
+      devpl_config[:env_api_key] = ENV['MNO_DEVPL_ENV_KEY'] || yaml_config['environment']['api_key']
+      devpl_config[:env_api_secret] = ENV['MNO_DEVPL_ENV_SECRET'] || yaml_config['environment']['api_secret']
+
+      raise 'Missing configuration' if devpl_config.values.any? { |v| v.nil? || v.empty? }
+
+      devpl_config
+    end
+  end
+end

--- a/lib/maestrano/auto_configure.rb
+++ b/lib/maestrano/auto_configure.rb
@@ -13,12 +13,12 @@ module Maestrano
           }
         )
         response = request.execute
-        response = JSON.parse(response.to_s)
+        hash = JSON.parse(response.to_s)
       rescue => e
         raise "No or bad response received from dev platform: #{e}"
       end
-
-      response['marketplaces'].each do |marketplace|
+puts "PARSING CONFIG: #{hash}"
+      hash['marketplaces'].each do |marketplace|
         Maestrano[marketplace['marketplace']].configure do |config|
           config.environment = marketplace['environment']
 
@@ -34,7 +34,7 @@ module Maestrano
     def self.dev_platform_config(config_file_path = nil)
       begin
         yaml_config = YAML.load_file("#{Dir.pwd}/#{config_file_path}")
-      rescue 
+      rescue
         yaml_config = {'dev_platform' => {}, 'environment' => {}}
       end
 

--- a/maestrano.gemspec
+++ b/maestrano.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('rest-client', '~> 1.8')
   s.add_dependency('mime-types', '~> 1.25')
   s.add_dependency('json', '~> 1.8')
-  s.add_dependency('httparty', '~> 0.13')
+  s.add_dependency('httparty', '~> 0.14')
 
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('mocha', '~> 1.1')

--- a/maestrano.gemspec
+++ b/maestrano.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('mocha', '~> 1.1')
   s.add_development_dependency('shoulda', '~> 3.5')
+  s.add_development_dependency('activesupport', '~> 4.2')
   s.add_development_dependency('timecop', '<= 0.6.0')
   s.add_development_dependency('rake', '~> 10')
 

--- a/maestrano.gemspec
+++ b/maestrano.gemspec
@@ -16,18 +16,18 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
-  
+
   s.add_dependency('rest-client', '~> 1.4')
   s.add_dependency('mime-types', '~> 1.25')
   s.add_dependency('json', '~> 1.8')
   s.add_dependency('httparty', '~> 0.13')
-  
-  s.add_development_dependency('test-unit', '~> 2')
-  s.add_development_dependency('mocha', '~> 0.13')
-  s.add_development_dependency('shoulda', '~> 2.11')
+
+  s.add_development_dependency('test-unit', '~> 3')
+  s.add_development_dependency('mocha', '~> 1.1')
+  s.add_development_dependency('shoulda', '~> 3.5')
   s.add_development_dependency('timecop', '<= 0.6.0')
   s.add_development_dependency('rake', '~> 10')
-  
+
   s.add_runtime_dependency("uuid", ["~> 2.3"])
   s.add_runtime_dependency("nokogiri", [">= 1.5.0"])
 end

--- a/test/maestrano/maestrano_test.rb
+++ b/test/maestrano/maestrano_test.rb
@@ -5,105 +5,105 @@ class MaestranoTest < Test::Unit::TestCase
     @config = {
       'environment'       => 'production',
       'app.host'          => 'http://mysuperapp.com',
-      
+
       'api.id'            => 'app-f54ds4f8',
       'api.key'           => 'someapikey',
 
       'connec.enabled'    => true,
-      
+
       'sso.enabled'       => false,
       'sso.slo_enabled'   => false,
       'sso.init_path'     => '/mno/sso/init',
       'sso.consume_path'  => '/mno/sso/consume',
       'sso.creation_mode' => 'real',
       'sso.idm'           => 'http://idp.mysuperapp.com',
-      
+
       'webhook.account.groups_path'       => '/mno/groups/:id',
       'webhook.account.group_users_path'  => '/mno/groups/:group_id/users/:id',
       'webhook.connec.notifications_path' => 'mno/receive',
       'webhook.connec.subscriptions'      => { organizations: true, people: true }
     }
-  
+
     Maestrano.configure do |config|
       config.environment = @config['environment']
       config.app.host = @config['app.host']
-      
+
       config.api.id = @config['api.id']
       config.api.key = @config['api.key']
 
       config.connec.enabled = @config['connec.enabled']
-      
+
       config.sso.enabled = @config['sso.enabled']
       config.sso.slo_enabled = @config['sso.slo_enabled']
       config.sso.idm = @config['sso.idm']
       config.sso.init_path = @config['sso.init_path']
       config.sso.consume_path = @config['sso.consume_path']
       config.sso.creation_mode = @config['sso.creation_mode']
-      
+
       config.webhook.account.groups_path = @config['webhook.account.groups_path']
       config.webhook.account.group_users_path = @config['webhook.account.group_users_path']
-      
+
       config.webhook.connec.notifications_path = @config['webhook.connec.notifications_path']
       config.webhook.connec.subscriptions = @config['webhook.connec.subscriptions']
     end
   end
-  
+
   context "new style configuration" do
     should "return the specified parameters" do
       @config.keys.each do |key|
         assert_equal @config[key], Maestrano.param(key)
       end
     end
-    
+
     should "set the sso.creation_mode to 'real' by default" do
       Maestrano.configs = {'default' => Maestrano::Configuration.new }
       Maestrano.configure { |config| config.app.host = "https://someapp.com" }
       assert_equal 'real', Maestrano.param('sso.creation_mode')
     end
-    
+
     should "build the api_token based on the app_id and api_key" do
       Maestrano.configure { |config| config.app_id = "bla"; config.api_key = "blo" }
       assert_equal "bla:blo", Maestrano.param('api.token')
     end
-  
+
     should "assign the sso.idm to app.host if not provided" do
       Maestrano.configs = {'default' => Maestrano::Configuration.new }
       Maestrano.configure { |config| config.app.host = "https://someapp.com" }
       assert_equal Maestrano.param('app.host'), Maestrano.param('sso.idm')
     end
-    
+
     should "force assign the api.lang" do
       Maestrano.configure { |config| config.api.lang = "bla" }
       assert_equal 'ruby', Maestrano.param('api.lang')
     end
-    
+
     should "force assign the api.lang_version" do
       Maestrano.configure { |config| config.api.lang_version = "123456" }
       assert_equal "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})", Maestrano.param('api.lang_version')
     end
-    
+
     should "force assign the api.version" do
       Maestrano.configure { |config| config.api.version = "1245" }
       assert_equal Maestrano::VERSION, Maestrano.param('api.version')
     end
-    
+
     should "force slo_enabled to false if sso is disabled" do
       Maestrano.configure { |config| config.sso.slo_enabled = true; config.sso.enabled = false }
       assert_false Maestrano.param('sso.slo_enabled')
     end
-    
+
     context "with environment params" do
       should "return the right test parameters" do
         Maestrano.configure { |config| config.environment = 'test' }
-      
+
         ['api.host', 'api.base', 'sso.idp', 'sso.name_id_format', 'sso.x509_certificate', 'connec.host', 'connec.base_path'].each do |parameter|
           assert_equal Maestrano::Configuration::EVT_CONFIG['test'][parameter], Maestrano.param(parameter)
         end
       end
-    
+
       should "return the right production parameters" do
         Maestrano.configure { |config| config.environment = 'production' }
-      
+
         ['api.host', 'api.base', 'sso.idp', 'sso.name_id_format', 'sso.x509_certificate', 'connec.host', 'connec.base_path'].each do |parameter|
           assert_equal Maestrano::Configuration::EVT_CONFIG['production'][parameter], Maestrano.param(parameter)
         end
@@ -118,19 +118,19 @@ class MaestranoTest < Test::Unit::TestCase
       @config = {
         'environment'       => 'production',
         'app.host'          => 'http://mysuperapp.com',
-        
+
         'api.id'            => 'app-f54ds4f8',
         'api.key'           => 'someapikey',
 
         'connec.enabled'    => true,
-        
+
         'sso.enabled'       => false,
         'sso.slo_enabled'   => false,
         'sso.init_path'     => '/mno/sso/init',
         'sso.consume_path'  => '/mno/sso/consume',
         'sso.creation_mode' => 'real',
         'sso.idm'           => 'http://idp.mysuperapp.com',
-        
+
         'webhook.account.groups_path'       => '/mno/groups/:id',
         'webhook.account.group_users_path'  => '/mno/groups/:group_id/users/:id',
         'webhook.connec.notifications_path' => 'mno/receive',
@@ -140,7 +140,7 @@ class MaestranoTest < Test::Unit::TestCase
       @preset_config = {
         'environment'       => 'production',
         'app.host'          => 'http://myotherapp.com',
-        
+
         'api.id'            => 'app-553941',
         'api.key'           => 'otherapikey',
       }
@@ -148,30 +148,30 @@ class MaestranoTest < Test::Unit::TestCase
       Maestrano.configure do |config|
         config.environment = @config['environment']
         config.app.host = @config['app.host']
-        
+
         config.api.id = @config['api.id']
         config.api.key = @config['api.key']
 
         config.connec.enabled = @config['connec.enabled']
-        
+
         config.sso.enabled = @config['sso.enabled']
         config.sso.slo_enabled = @config['sso.slo_enabled']
         config.sso.idm = @config['sso.idm']
         config.sso.init_path = @config['sso.init_path']
         config.sso.consume_path = @config['sso.consume_path']
         config.sso.creation_mode = @config['sso.creation_mode']
-        
+
         config.webhook.account.groups_path = @config['webhook.account.groups_path']
         config.webhook.account.group_users_path = @config['webhook.account.group_users_path']
-        
+
         config.webhook.connec.notifications_path = @config['webhook.connec.notifications_path']
         config.webhook.connec.subscriptions = @config['webhook.connec.subscriptions']
       end
-    
+
       Maestrano[@preset].configure do |config|
         config.environment = @preset_config['environment']
         config.app.host = @preset_config['app.host']
-        
+
         config.api.id = @preset_config['api.id']
         config.api.key = @preset_config['api.key']
       end
@@ -182,39 +182,39 @@ class MaestranoTest < Test::Unit::TestCase
         assert_equal @preset_config[key], Maestrano[@preset].param(key)
       end
     end
-    
+
     should "set the sso.creation_mode to 'real' by default" do
       Maestrano.configs = {@preset => Maestrano::Configuration.new }
       Maestrano[@preset].configure { |config| config.app.host = "https://someapp.com" }
       assert_equal 'real', Maestrano[@preset].param('sso.creation_mode')
     end
-    
+
     should "build the api_token based on the app_id and api_key" do
       Maestrano[@preset].configure { |config| config.app_id = "bla"; config.api_key = "blo" }
       assert_equal "bla:blo", Maestrano[@preset].param('api.token')
     end
-  
+
     should "assign the sso.idm to app.host if not provided" do
       Maestrano.configs = {@preset => Maestrano::Configuration.new }
       Maestrano[@preset].configure { |config| config.app.host = "https://someapp.com" }
       assert_equal Maestrano[@preset].param('app.host'), Maestrano[@preset].param('sso.idm')
     end
-    
+
     should "force assign the api.lang" do
       Maestrano[@preset].configure { |config| config.api.lang = "bla" }
       assert_equal 'ruby', Maestrano[@preset].param('api.lang')
     end
-    
+
     should "force assign the api.lang_version" do
       Maestrano[@preset].configure { |config| config.api.lang_version = "123456" }
       assert_equal "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})", Maestrano[@preset].param('api.lang_version')
     end
-    
+
     should "force assign the api.version" do
       Maestrano[@preset].configure { |config| config.api.version = "1245" }
       assert_equal Maestrano::VERSION, Maestrano[@preset].param('api.version')
     end
-    
+
     should "force slo_enabled to false if sso is disabled" do
       Maestrano[@preset].configure { |config| config.sso.slo_enabled = true; config.sso.enabled = false }
       assert_false Maestrano[@preset].param('sso.slo_enabled')
@@ -225,19 +225,19 @@ class MaestranoTest < Test::Unit::TestCase
       assert_equal 'http://mydataserver.org', Maestrano[@preset].param('connec.host')
       assert_equal '/data', Maestrano[@preset].param('connec.base_path')
     end
-    
+
     context "with environment params" do
       should "return the right test parameters" do
         Maestrano[@preset].configure { |config| config.environment = 'test' }
-      
+
         ['api.host','api.base','sso.idp', 'sso.name_id_format', 'sso.x509_certificate', 'connec.host','connec.base_path'].each do |parameter|
           assert_equal Maestrano::Configuration::EVT_CONFIG['test'][parameter], Maestrano[@preset].param(parameter)
         end
       end
-    
+
       should "return the right production parameters" do
         Maestrano[@preset].configure { |config| config.environment = 'production' }
-      
+
         ['api.host','api.base','sso.idp', 'sso.name_id_format', 'sso.x509_certificate','connec.host','connec.base_path'].each do |parameter|
           assert_equal Maestrano::Configuration::EVT_CONFIG['production'][parameter], Maestrano[@preset].param(parameter)
         end
@@ -315,14 +315,14 @@ class MaestranoTest < Test::Unit::TestCase
           should 'creates a new preset' do
             assert_nothing_raised { Maestrano.auto_configure('test/support/yml/dev_platform.yml') }
             @new_preset_config.keys.each do |key|
-              assert_equal @new_preset_config[key], Maestrano[@new_preset].param(key)
+              assert_equal @new_preset_config[key], Maestrano[@new_preset].param(key).marshal_dump
             end
           end
 
           should 'overload the exisiting preset (only if it is called after)' do
             assert_nothing_raised { Maestrano.auto_configure('test/support/yml/dev_platform.yml') }
             @preset_config.keys.reject { |k| k == :app }.each do |key|
-              assert_equal @preset_config[key], Maestrano[@preset].param(key)
+              assert_equal @preset_config[key], Maestrano[@preset].param(key).marshal_dump
             end
             assert_equal @marketplaces[:marketplaces].last[:app], Maestrano[@preset].param('app')
           end
@@ -330,8 +330,8 @@ class MaestranoTest < Test::Unit::TestCase
 
       end
     end
-  end  
-  
+  end
+
   context "old style configuration" do
     setup do
       @config = {
@@ -343,7 +343,7 @@ class MaestranoTest < Test::Unit::TestCase
         sso_app_consume_path: '/mno/sso/consume',
         user_creation_mode: 'real',
       }
-    
+
       Maestrano.configure do |config|
         config.environment = @config[:environment]
         config.api_key = @config[:api_key]
@@ -354,51 +354,51 @@ class MaestranoTest < Test::Unit::TestCase
         config.user_creation_mode = @config[:user_creation_mode]
       end
     end
-    
+
     should "build the api_token based on the app_id and api_key" do
       Maestrano.configure { |config| config.app_id = "bla"; config.api_key = "blo" }
       assert_equal "bla:blo", Maestrano.param(:api_token)
     end
-    
+
     should "assign the sso.idm if explicitly set to nil" do
       Maestrano.configure { |config| config.sso.idm = nil }
       assert_equal Maestrano.param('app.host'), Maestrano.param('sso.idm')
     end
-    
+
     should "force assign the api.lang" do
       Maestrano.configure { |config| config.api.lang = "bla" }
       assert_equal 'ruby', Maestrano.param('api.lang')
     end
-    
+
     should "force assign the api.lang_version" do
       Maestrano.configure { |config| config.api.lang_version = "123456" }
       assert_equal "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})", Maestrano.param('api.lang_version')
     end
-    
+
     should "force assign the api.version" do
       Maestrano.configure { |config| config.api.version = "1245" }
       assert_equal Maestrano::VERSION, Maestrano.param('api.version')
     end
-    
+
     should "return the specified parameters" do
       @config.keys.each do |key|
         assert Maestrano.param(key) == @config[key]
       end
     end
-    
+
     context "with environment params" do
       should "return the right test parameters" do
         Maestrano.configure { |config| config.environment = 'test' }
-      
+
         ['api_host','api_base','sso_name_id_format', 'sso_x509_certificate'].each do |parameter|
           key = Maestrano::Configuration.new.legacy_param_to_new(parameter)
           assert_equal Maestrano::Configuration::EVT_CONFIG['test'][key], Maestrano.param(parameter)
         end
       end
-    
+
       should "return the right production parameters" do
         Maestrano.configure { |config| config.environment = 'production' }
-      
+
         ['api_host','api_base','sso_name_id_format', 'sso_x509_certificate'].each do |parameter|
           key = Maestrano::Configuration.new.legacy_param_to_new(parameter)
           assert_equal Maestrano::Configuration::EVT_CONFIG['production'][key], Maestrano.param(parameter)
@@ -406,45 +406,45 @@ class MaestranoTest < Test::Unit::TestCase
       end
     end
   end
-  
+
   context "authenticate" do
     should "return true if app_id and api_key match" do
       assert Maestrano.authenticate(Maestrano.param(:app_id),Maestrano.param(:api_key))
     end
-    
+
     should "return false otherwise" do
       assert !Maestrano.authenticate(Maestrano.param(:app_id) + 'a',Maestrano.param(:api_key))
       assert !Maestrano.authenticate(Maestrano.param(:app_id),Maestrano.param(:api_key) + 'a')
     end
   end
-  
+
   context "mask_user_uid" do
     should "return the composite uid if creation_mode is virtual" do
       Maestrano.configure { |c| c.user_creation_mode = 'virtual' }
       assert_equal 'usr-1.cld-1', Maestrano.mask_user('usr-1','cld-1')
     end
-    
+
     should "not double up the composite uid" do
       Maestrano.configure { |c| c.user_creation_mode = 'virtual' }
       assert_equal 'usr-1.cld-1', Maestrano.mask_user('usr-1.cld-1','cld-1')
     end
-    
+
     should "return the real uid if creation_mode is real" do
       Maestrano.configure { |c| c.user_creation_mode = 'real' }
       assert_equal 'usr-1', Maestrano.mask_user('usr-1','cld-1')
     end
   end
-  
+
   context "unmask_user_uid" do
     should "return the right uid if composite" do
       assert_equal 'usr-1', Maestrano.unmask_user('usr-1.cld-1')
     end
-    
+
     should "return the right uid if non composite" do
       assert_equal 'usr-1', Maestrano.unmask_user('usr-1')
     end
   end
-  
+
   context "to_metadata" do
     should "should return the right hash" do
       expected = {
@@ -460,7 +460,7 @@ class MaestranoTest < Test::Unit::TestCase
           'lang_version'     => "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
           'host'             => Maestrano::Configuration::EVT_CONFIG[@config['environment']]['api.host'],
           'base'             => Maestrano::Configuration::EVT_CONFIG[@config['environment']]['api.base'],
-          
+
         },
         'sso' => {
           'enabled'          => @config['sso.enabled'],
@@ -485,9 +485,9 @@ class MaestranoTest < Test::Unit::TestCase
           }
         }
       }
-      
+
       assert_equal expected, Maestrano.to_metadata
     end
   end
-  
+
 end

--- a/test/support/yml/dev_platform.yml
+++ b/test/support/yml/dev_platform.yml
@@ -1,0 +1,8 @@
+dev_platform:
+  host: 'http://localhost:5000'
+  v1_path: '/api/config/v1/marketplaces'
+
+environment: 
+  name: 'test'
+  api_key: '123'
+  api_secret: '123'

--- a/test/support/yml/dev_platform.yml
+++ b/test/support/yml/dev_platform.yml
@@ -1,8 +1,8 @@
 dev_platform:
   host: 'http://localhost:5000'
-  v1_path: '/api/config/v1/marketplaces'
+  api_path: '/api/config/v1/marketplaces'
 
-environment: 
+environment:
   name: 'test'
   api_key: '123'
   api_secret: '123'

--- a/test/support/yml/wrong_dev_platform.yml
+++ b/test/support/yml/wrong_dev_platform.yml
@@ -1,8 +1,8 @@
 dev_platform:
   host: 'stuff'
-  v1_path: 'stuff'
+  api_path: 'stuff'
 
-environment: 
+environment:
   name: 'test'
   api_key: '123'
   api_secret: '123'

--- a/test/support/yml/wrong_dev_platform.yml
+++ b/test/support/yml/wrong_dev_platform.yml
@@ -1,0 +1,8 @@
+dev_platform:
+  host: 'stuff'
+  v1_path: 'stuff'
+
+environment: 
+  name: 'test'
+  api_key: '123'
+  api_secret: '123'


### PR DESCRIPTION
Configuration can be loaded from the developer platform:

Readme has been updated with the following:

#### Configuration based of the Developer Platform
Your environment configuration is retrieved from the developer platform where your different environments are registered.
In your initializer add the following configuration:

`config/initializers/maestrano.rb`
```ruby
Maestrano.auto_configure('config/dev_platform.yml')
```
`dev_platform.yml`
```yml
dev_platform:
  host: 'https://dev-platform.maestrano.com'
  api_path: '/api/config/v1/marketplaces'

environment:
  name: 'my-environment'
  api_key: 'your-environment-api-key'
  api_secret: 'your-environment-api-secret'
```
The API keys can be found under your Environment settings on the developer platform.

Note that the configuration can also be set from environment variables:

```bash
export MNO_DEVPL_HOST=<developer platform host>
export MNO_DEVPL_API_PATH=<developer platform path>
export MNO_DEVPL_ENV_NAME=<your environment nid>
export MNO_DEVPL_ENV_KEY=<your environment key>
export MNO_DEVPL_ENV_SECRET=<your environment secret>
```

`config/initializers/maestrano.rb`
```ruby
Maestrano.auto_configure
```